### PR TITLE
Allow custom formatting of cut off date

### DIFF
--- a/jquery.timeago.js
+++ b/jquery.timeago.js
@@ -45,6 +45,8 @@
       allowFuture: false,
       localeTitle: false,
       cutoff: 0,
+      cutoffLocales: null, // For cutoffLocales and cutoffOptions see
+      cutoffOptions: {},   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString
       autoDispose: true,
       strings: {
         prefixAgo: null,
@@ -192,6 +194,9 @@
     if (!isNaN(data.datetime)) {
       if ( $s.cutoff == 0 || Math.abs(distance(data.datetime)) < $s.cutoff) {
         $(this).text(inWords(data.datetime));
+      } else if ($s.cutoffLocales && typeof Date.prototype.toLocaleString == 'function') {
+        var $date = new Date(data.datetime);
+        $(this).text($date.toLocaleString($s.cutoffLocales, $s.cutoffOptions));
       }
     }
     return this;


### PR DESCRIPTION
Allow custom formatting of cut off date

```
    jQuery.timeago.settings.cutoff = 1000*60*60*24;
    jQuery.timeago.settings.cutoffLocales = "en-GB";
```

Shows date as: 21/04/2016, 07:33:23 instead of Thu, 21 Apr 2016 08:33:23 +0200

```
    jQuery.timeago.settings.cutoff = 1000*60*60*24;
    jQuery.timeago.settings.cutoffLocales = "de-DE";
    jQuery.timeago.settings.cutoffOptions =  { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
```

shows the above date as: Donnerstag, 21. April 2016
